### PR TITLE
some fixes to timestepping

### DIFF
--- a/Source/Evolve.cpp
+++ b/Source/Evolve.cpp
@@ -163,9 +163,10 @@ void Vidyut::Evolve()
                
         for(int niter=0;niter<num_timestep_correctors;niter++)
         {
-            //reset all
+            //for second order accuracy in mid-point method
             amrex::Real time_offset=(niter>0)?0.5*dt_common:0.0;
            
+            //reset all
             for(int lev=0;lev<=finest_level;lev++)
             {
                 Sborder[lev].setVal(0.0);

--- a/Source/Evolve.cpp
+++ b/Source/Evolve.cpp
@@ -164,6 +164,8 @@ void Vidyut::Evolve()
         for(int niter=0;niter<num_timestep_correctors;niter++)
         {
             //reset all
+            amrex::Real time_offset=(niter>0)?0.5*dt_common:0.0;
+           
             for(int lev=0;lev<=finest_level;lev++)
             {
                 Sborder[lev].setVal(0.0);
@@ -185,7 +187,8 @@ void Vidyut::Evolve()
                 photoion_src_total[lev].setVal(0.0);
             }
 
-            solve_potential(cur_time, Sborder, pot_bc_lo, pot_bc_hi, efield_fc);
+            //add dt/2 after niter=0
+            solve_potential(cur_time+time_offset, Sborder, pot_bc_lo, pot_bc_hi, efield_fc);
 
             if(cs_technique)
             {
@@ -230,7 +233,7 @@ void Vidyut::Evolve()
             // Calculate the reactive source terms for all species/levels
             if(do_reactions)
             {
-                update_rxnsrc_at_all_levels(Sborder, rxn_src, cur_time);
+                update_rxnsrc_at_all_levels(Sborder, rxn_src, cur_time+time_offset);
             }
 
   
@@ -238,7 +241,7 @@ void Vidyut::Evolve()
             {
                 //First add the photoionization source jth component to the total photoionization source multifab
                 //In the same loop over levels, add the inidividual components to rxn_src
-                solve_photoionization(cur_time, Sborder, photoion_bc_lo, photoion_bc_hi, photoion_src, 0);
+                solve_photoionization(cur_time+time_offset, Sborder, photoion_bc_lo, photoion_bc_hi, photoion_src, 0);
                 for (int ilev=0; ilev <= finest_level; ilev++)
                 {
                     amrex::MultiFab::Saxpy(photoion_src_total[ilev], 1.0, photoion_src[ilev], 0, 0, 1, 0);
@@ -246,7 +249,7 @@ void Vidyut::Evolve()
                     amrex::MultiFab::Saxpy(rxn_src[ilev], 1.0, photoion_src[ilev], 0, photoion_ID, 1, 0);
                 }
 
-                solve_photoionization(cur_time, Sborder, photoion_bc_lo, photoion_bc_hi, photoion_src, 1);
+                solve_photoionization(cur_time+time_offset, Sborder, photoion_bc_lo, photoion_bc_hi, photoion_src, 1);
                 for (int ilev=0; ilev <= finest_level; ilev++)
                 {
                     amrex::MultiFab::Saxpy(photoion_src_total[ilev], 1.0, photoion_src[ilev], 0, 0, 1, 0);
@@ -254,7 +257,7 @@ void Vidyut::Evolve()
                     amrex::MultiFab::Saxpy(rxn_src[ilev], 1.0, photoion_src[ilev], 0, photoion_ID, 1, 0);
                 }    
 
-                solve_photoionization(cur_time, Sborder, photoion_bc_lo, photoion_bc_hi, photoion_src, 2);
+                solve_photoionization(cur_time+time_offset, Sborder, photoion_bc_lo, photoion_bc_hi, photoion_src, 2);
                 for (int ilev=0; ilev <= finest_level; ilev++)
                 {
                     amrex::MultiFab::Saxpy(photoion_src_total[ilev], 1.0, photoion_src[ilev], 0, 0, 1, 0);
@@ -267,15 +270,15 @@ void Vidyut::Evolve()
             }
             
             //electron density solve
-            update_explsrc_at_all_levels(E_IDX, Sborder, flux, rxn_src, expl_src, eden_bc_lo, eden_bc_hi, cur_time);
-            implicit_solve_scalar(cur_time,dt_common,E_IDX,Sborder,Sborder_old,expl_src,eden_bc_lo,eden_bc_hi, gradne_fc);
+            update_explsrc_at_all_levels(E_IDX, Sborder, flux, rxn_src, expl_src, eden_bc_lo, eden_bc_hi, cur_time+time_offset);
+            implicit_solve_scalar(cur_time+time_offset,dt_common,E_IDX,Sborder,Sborder_old,expl_src,eden_bc_lo,eden_bc_hi, gradne_fc);
 
             //electron energy solve
             if(elecenergy_solve)
             {
                 update_explsrc_at_all_levels(EEN_ID, Sborder, flux, rxn_src, expl_src, 
                                              eenrg_bc_lo,eenrg_bc_hi,
-                                             cur_time);
+                                             cur_time+time_offset);
                 
                 for (int lev = 0; lev <= finest_level; lev++)
                 {
@@ -283,10 +286,10 @@ void Vidyut::Evolve()
                                               rxn_src[lev], 
                                               efield_fc[lev],
                                               gradne_fc[lev],
-                                              expl_src[lev], cur_time, dt_common,floor_jh);
+                                              expl_src[lev], cur_time+time_offset, dt_common,floor_jh);
                 }
 
-                implicit_solve_scalar(cur_time,dt_common,EEN_ID, Sborder,Sborder_old, 
+                implicit_solve_scalar(cur_time+time_offset,dt_common,EEN_ID, Sborder,Sborder_old, 
                                       expl_src,eenrg_bc_lo,eenrg_bc_hi, grad_fc);
             }
 
@@ -310,18 +313,18 @@ void Vidyut::Evolve()
                     if(plasmachem::get_charge(ind)!=0)
                     {
                         update_explsrc_at_all_levels(ind, Sborder, flux, rxn_src,
-                                                     expl_src, ion_bc_lo, ion_bc_hi, cur_time);
+                                                     expl_src, ion_bc_lo, ion_bc_hi, cur_time+time_offset);
                         
-                        implicit_solve_scalar(cur_time, dt_common, ind, Sborder, Sborder_old,
+                        implicit_solve_scalar(cur_time+time_offset, dt_common, ind, Sborder, Sborder_old,
                                               expl_src,ion_bc_lo,ion_bc_hi, grad_fc);
                     }
                     //neutrals
                     else
                     {
                         update_explsrc_at_all_levels(ind, Sborder, flux, rxn_src, expl_src, 
-                                                     neutral_bc_lo, neutral_bc_hi, cur_time);
+                                                     neutral_bc_lo, neutral_bc_hi, cur_time+time_offset);
 
-                        implicit_solve_scalar(cur_time, dt_common, ind, Sborder, Sborder_old,
+                        implicit_solve_scalar(cur_time+time_offset, dt_common, ind, Sborder, Sborder_old,
                                               expl_src,neutral_bc_lo,neutral_bc_hi, grad_fc);
                     }
                 } 
@@ -349,7 +352,7 @@ void Vidyut::Evolve()
 
                 if(track_surf_charge)
                 {
-                   update_surf_charge(Sborder,cur_time,dt_common);
+                   update_surf_charge(Sborder,cur_time+time_offset,dt_common);
                 }
             }
 

--- a/Source/ScalarSolve.cpp
+++ b/Source/ScalarSolve.cpp
@@ -260,6 +260,7 @@ void Vidyut::compute_axisym_correction(int lev, MultiFab& Sborder,MultiFab& dsdt
     amrex::Real captured_gastemp=gas_temperature;
     amrex::Real captured_gaspres=gas_pressure;
     const auto dx = geom[lev].CellSizeArray();
+    auto prob_lo = geom[lev].ProbLoArray();
 
     for (MFIter mfi(dsdt, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
@@ -270,8 +271,9 @@ void Vidyut::compute_axisym_correction(int lev, MultiFab& Sborder,MultiFab& dsdt
 
         // Evaluate cell-centered axisymmetric source terms (Gamma_k / r)
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-          // calculate r
-          amrex::Real rval = amrex::Math::abs((i+0.5) * dx[0]);
+          // calculate r which is always x
+          // ideally x will be positive for axisymmetric cases
+          amrex::Real rval = amrex::Math::abs(prob_lo[0]+(i+0.5)*dx[0]);
 
           // Calculate the advective source term component
           amrex::Real etemp = s_arr(i,j,k,ETEMP_ID);

--- a/Source/TimeStep.cpp
+++ b/Source/TimeStep.cpp
@@ -13,16 +13,22 @@
 // a wrapper for EstTimeStep
 void Vidyut::ComputeDt(amrex::Real cur_time, amrex::Real dt_delay, amrex::Real dt_edrift, amrex::Real dt_ediff, amrex::Real dt_diel_relax)
 {
-    if(adaptive_dt && cur_time > dt_delay){
-      amrex::Real old_dt = dt[0];
-      amrex::Real trans_min_dt = std::numeric_limits<Real>::max();
-      amrex::Real adp_dt = std::numeric_limits<Real>::max();
-      if(do_transport) trans_min_dt = std::min(dt_edrift*advective_cfl, dt_ediff*diffusive_cfl);
-      adp_dt = std::min(trans_min_dt, dt_diel_relax*dielectric_cfl);
-      if(adp_dt > dt_max) adp_dt = dt_max;
-      if(adp_dt < dt_min) adp_dt = dt_min;
-      dt[0] = std::min(old_dt*dt_stretch, adp_dt);
+    if(adaptive_dt && cur_time > dt_delay)
+    {
+        amrex::Real old_dt = dt[0];
+        amrex::Real trans_min_dt = std::numeric_limits<Real>::max();
+        amrex::Real adp_dt = std::numeric_limits<Real>::max();
+        if(do_transport) trans_min_dt = std::min(dt_edrift*advective_cfl, dt_ediff*diffusive_cfl);
+        adp_dt = std::min(trans_min_dt, dt_diel_relax*dielectric_cfl);
+        if(adp_dt > dt_max) adp_dt = dt_max;
+        if(adp_dt < dt_min) adp_dt = dt_min;
+        dt[0] = std::min(old_dt*dt_stretch, adp_dt);
     }
+    else
+    {
+        dt[0]=fixed_dt; //from input file
+    }
+
 
     for (int lev = 1; lev <= finest_level; ++lev)
     {
@@ -32,7 +38,7 @@ void Vidyut::ComputeDt(amrex::Real cur_time, amrex::Real dt_delay, amrex::Real d
 
 // compute dt from CFL considerations
 void Vidyut::find_time_scales(int lev,amrex::Real& dt_edrift,amrex::Real &dt_ediff,
-            amrex::Real& dt_diel_relax)
+                              amrex::Real& dt_diel_relax)
 {
     BL_PROFILE("Vidyut::EstTimeStep()");
     dt_edrift = std::numeric_limits<Real>::max();
@@ -41,7 +47,7 @@ void Vidyut::find_time_scales(int lev,amrex::Real& dt_edrift,amrex::Real &dt_edi
 
     const auto dx = geom[lev].CellSizeArray();
     MultiFab& S_new = phi_new[lev];
-    
+
     amrex::Real captured_gastemp=gas_temperature;
     amrex::Real captured_gaspres=gas_pressure;
     int eidx = E_IDX;
@@ -61,25 +67,25 @@ void Vidyut::find_time_scales(int lev,amrex::Real& dt_edrift,amrex::Real &dt_edi
             Array4<Real> ediff_array = ediff.array(mfi);
             Array4<Real> mue_ne_array = mue_ne.array(mfi);
             auto prob_lo = geom[lev].ProbLoArray();
-            
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
-            {
-                amrex::Real etemp=state_array(i,j,k,ETEMP_ID); 
-                amrex::Real Esum = 0.0;
-                for (int dim = 0; dim < AMREX_SPACEDIM; dim++) Esum += std::pow(state_array(i,j,k,EFX_ID+dim),2.0);
-                amrex::Real efield_mag=std::sqrt(Esum);
-               
-                amrex::Real ndens = 0.0; 
-                for(int sp=0; sp<NUM_SPECIES; sp++) ndens += state_array(i,j,k,sp);
 
-                amrex::Real dcoeff = specDiff(eidx, etemp, ndens, efield_mag,captured_gastemp);
-                
-                amrex::Real mu = specMob(eidx, etemp, ndens, efield_mag, captured_gastemp);
-                
-                edriftvel_array(i,j,k)=amrex::Math::abs(mu)*efield_mag;
-                ediff_array(i,j,k)=dcoeff;
-                mue_ne_array(i,j,k)=amrex::Math::abs(mu)*state_array(i,j,k,eidx);
-            });
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) 
+                               {
+                                   amrex::Real etemp=state_array(i,j,k,ETEMP_ID); 
+                                   amrex::Real Esum = 0.0;
+                                   for (int dim = 0; dim < AMREX_SPACEDIM; dim++) Esum += std::pow(state_array(i,j,k,EFX_ID+dim),2.0);
+                                   amrex::Real efield_mag=std::sqrt(Esum);
+
+                                   amrex::Real ndens = 0.0; 
+                                   for(int sp=0; sp<NUM_SPECIES; sp++) ndens += state_array(i,j,k,sp);
+
+                                   amrex::Real dcoeff = specDiff(eidx, etemp, ndens, efield_mag,captured_gastemp);
+
+                                   amrex::Real mu = specMob(eidx, etemp, ndens, efield_mag, captured_gastemp);
+
+                                   edriftvel_array(i,j,k)=amrex::Math::abs(mu)*efield_mag;
+                                   ediff_array(i,j,k)=dcoeff;
+                                   mue_ne_array(i,j,k)=amrex::Math::abs(mu)*state_array(i,j,k,eidx);
+                               });
         }
     }
 


### PR DESCRIPTION
1) adding dt/2 to time variable for ensuring
second order accuracy using midpoint method

2) fixing dt[0] to fixed dt in computeDt call

3) axisym correction needs prob_lo[0] for finding r