### PR TITLE
Fix Ar-H2 diffusion fallback and standardize dcoeff defaults with case-specific exceptions

### DIFF
--- a/test/models/ArH2_MultiStreamers3d/Chemistry.H
+++ b/test/models/ArH2_MultiStreamers3d/Chemistry.H
@@ -280,7 +280,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real elecmob = specMob(E_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; //dummy value
 
     // special case
     Tg_in_ev = P_NTP / ndens / K_B / eV;
@@ -319,11 +319,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     if (specid == NUM_SPECIES)
     {
         dcoeff = fivebythree * Te_in_ev * amrex::Math::abs(elecmob);
-    } else // shouldnt come to this ideally
-    {
-        amrex::Real ionmob = specMob(ARp_ID, Te, ndens, emag, T);
-        dcoeff = Tg_in_ev * amrex::Math::abs(ionmob);
-    }
+    } 
 
     return (dcoeff);
 }

--- a/test/models/ArH2_MultiStreamers3d/Chemistry.H
+++ b/test/models/ArH2_MultiStreamers3d/Chemistry.H
@@ -280,7 +280,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real elecmob = specMob(E_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 1e-12; //dummy value
+    amrex::Real dcoeff = 1e-12; // dummy value
 
     // special case
     Tg_in_ev = P_NTP / ndens / K_B / eV;
@@ -319,7 +319,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     if (specid == NUM_SPECIES)
     {
         dcoeff = fivebythree * Te_in_ev * amrex::Math::abs(elecmob);
-    } 
+    }
 
     return (dcoeff);
 }

--- a/test/models/Ar_DBD/Chemistry.H
+++ b/test/models/Ar_DBD/Chemistry.H
@@ -210,7 +210,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real elecmob = specMob(E_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
 
     if (specid == E_ID)
     {

--- a/test/models/Ar_DC_1d/Chemistry.H
+++ b/test/models/Ar_DC_1d/Chemistry.H
@@ -232,7 +232,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real ionmob = specMob(ARp_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
 
     if (specid == E_ID)
     {

--- a/test/models/Ar_RF_Sputter3d/Chemistry.H
+++ b/test/models/Ar_RF_Sputter3d/Chemistry.H
@@ -210,7 +210,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real elecmob = specMob(E_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
 
     if (specid == E_ID)
     {

--- a/test/models/Axisymmetric_streamer_Ar/Chemistry.H
+++ b/test/models/Axisymmetric_streamer_Ar/Chemistry.H
@@ -229,7 +229,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real ionmob = specMob(ARp_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
 
     if (specid == E_ID)
     {

--- a/test/models/OffsetElectrodesRF/Chemistry.H
+++ b/test/models/OffsetElectrodesRF/Chemistry.H
@@ -264,7 +264,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real Te_in_eV = Te / eV;
     amrex::Real Tg_in_eV = T / eV;
     amrex::Real mob;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     if (specid == E_ID)
     {
         mob = specMob(specid, Te, ndens, emag, T);

--- a/test/models/RingElectrodeRF/Chemistry.H
+++ b/test/models/RingElectrodeRF/Chemistry.H
@@ -264,7 +264,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real Te_in_eV = Te / eV;
     amrex::Real Tg_in_eV = T / eV;
     amrex::Real mob;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     if (specid == E_ID)
     {
         mob = specMob(specid, Te, ndens, emag, T);

--- a/test/models/Streamer3d/Chemistry.H
+++ b/test/models/Streamer3d/Chemistry.H
@@ -229,7 +229,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real ionmob = specMob(ARp_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
 
     if (specid == E_ID)
     {

--- a/test/models/ionelec_DC_1d/Chemistry.H
+++ b/test/models/ionelec_DC_1d/Chemistry.H
@@ -212,7 +212,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     amrex::Real elecdcoeff = 100.0;
     if (specid == E_ID)
     {

--- a/test/verification/Advect/Chemistry.H
+++ b/test/verification/Advect/Chemistry.H
@@ -169,7 +169,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     return (dcoeff);
 }
 

--- a/test/verification/Advect/Chemistry.H
+++ b/test/verification/Advect/Chemistry.H
@@ -169,7 +169,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 1e-12; // dummy value
+    amrex::Real dcoeff = 0.0;
     return (dcoeff);
 }
 

--- a/test/verification/BoundaryLayer/Chemistry.H
+++ b/test/verification/BoundaryLayer/Chemistry.H
@@ -193,7 +193,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     if (specid == S1_ID)
     {
         dcoeff = 0.1;

--- a/test/verification/GEC_RF_Cell/Chemistry.H
+++ b/test/verification/GEC_RF_Cell/Chemistry.H
@@ -210,7 +210,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real elecmob = specMob(E_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
 
     if (specid == E_ID)
     {

--- a/test/verification/He_RF_1d/Chemistry.H
+++ b/test/verification/He_RF_1d/Chemistry.H
@@ -264,7 +264,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real Te_in_eV = Te / eV;
     amrex::Real Tg_in_eV = T / eV;
     amrex::Real mob;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     if (specid == E_ID)
     {
         mob = specMob(specid, Te, ndens, emag, T);

--- a/test/verification/Laplace_2D/Chemistry.H
+++ b/test/verification/Laplace_2D/Chemistry.H
@@ -193,7 +193,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     return (dcoeff);
 }
 

--- a/test/verification/Laplace_2D_RobinBC_Test/Chemistry.H
+++ b/test/verification/Laplace_2D_RobinBC_Test/Chemistry.H
@@ -193,7 +193,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     return (dcoeff);
 }
 

--- a/test/verification/Laplace_2D_RobinBC_Test_EB/Chemistry.H
+++ b/test/verification/Laplace_2D_RobinBC_Test_EB/Chemistry.H
@@ -193,7 +193,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     return (dcoeff);
 }
 

--- a/test/verification/Laplace_Axisym/Chemistry.H
+++ b/test/verification/Laplace_Axisym/Chemistry.H
@@ -193,7 +193,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     return (dcoeff);
 }
 

--- a/test/verification/MMS1/Chemistry.H
+++ b/test/verification/MMS1/Chemistry.H
@@ -168,7 +168,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     if (specid == NI_ID)
     {
         dcoeff = 1.0;

--- a/test/verification/MMS1_Axisym/Chemistry.H
+++ b/test/verification/MMS1_Axisym/Chemistry.H
@@ -168,7 +168,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     if (specid == NI_ID)
     {
         dcoeff = 1.0;

--- a/test/verification/MMS1_Axisym_EB/Chemistry.H
+++ b/test/verification/MMS1_Axisym_EB/Chemistry.H
@@ -168,7 +168,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     if (specid == NI_ID)
     {
         dcoeff = 1.0;

--- a/test/verification/MMS2/Chemistry.H
+++ b/test/verification/MMS2/Chemistry.H
@@ -191,7 +191,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     amrex::Real elecdcoeff = 1.0;
     amrex::Real iondcoeff = 0.5;
     if (specid == E_ID)

--- a/test/verification/MMS2_Axisym/Chemistry.H
+++ b/test/verification/MMS2_Axisym/Chemistry.H
@@ -191,7 +191,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     amrex::Real elecdcoeff = 1.0;
     amrex::Real iondcoeff = 0.5;
     if (specid == E_ID)

--- a/test/verification/MMS2_Axisym_EB/Chemistry.H
+++ b/test/verification/MMS2_Axisym_EB/Chemistry.H
@@ -191,7 +191,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     amrex::Real elecdcoeff = 1.0;
     amrex::Real iondcoeff = 0.5;
     if (specid == E_ID)

--- a/test/verification/MMS2_Axisym_EB_AMReX_Direct/Chemistry.H
+++ b/test/verification/MMS2_Axisym_EB_AMReX_Direct/Chemistry.H
@@ -191,7 +191,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     amrex::Real elecdcoeff = 1.0;
     amrex::Real iondcoeff = 0.5;
     if (specid == E_ID)

--- a/test/verification/MMS3/Chemistry.H
+++ b/test/verification/MMS3/Chemistry.H
@@ -191,7 +191,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     amrex::Real elecdcoeff = 0.0;
     amrex::Real iondcoeff = 0.0;
     if (specid == E_ID)

--- a/test/verification/Streamer_Axisym/Chemistry.H
+++ b/test/verification/Streamer_Axisym/Chemistry.H
@@ -209,7 +209,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     amrex::Real elecdcoeff = 4.3628e-3 * std::pow(emag, 0.22);
     if (specid == E_ID)
     {

--- a/test/verification/Streamer_Axisym_Photoion/Chemistry.H
+++ b/test/verification/Streamer_Axisym_Photoion/Chemistry.H
@@ -209,7 +209,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     const amrex::Real emag,
     const amrex::Real T)
 {
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
     amrex::Real elecdcoeff = 4.3628e-3 * std::pow(emag, 0.22);
     if (specid == E_ID)
     {

--- a/test/zeroD_Reactors/ArH2_ns_pulse/Chemistry.H
+++ b/test/zeroD_Reactors/ArH2_ns_pulse/Chemistry.H
@@ -302,7 +302,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real elecmob = specMob(E_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 1e-12; // dummy value
+    amrex::Real dcoeff = 0.0;
 
     // special case
     /*Tg_in_ev=P_NTP/ndens/K_B/eV;

--- a/test/zeroD_Reactors/ArH2_ns_pulse/Chemistry.H
+++ b/test/zeroD_Reactors/ArH2_ns_pulse/Chemistry.H
@@ -302,7 +302,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real specDiff(
     amrex::Real elecmob = specMob(E_ID, Te, ndens, emag, T);
     amrex::Real Te_in_ev = Te / eV;
     amrex::Real Tg_in_ev = T / eV;
-    amrex::Real dcoeff = 0.0;
+    amrex::Real dcoeff = 1e-12; // dummy value
 
     // special case
     /*Tg_in_ev=P_NTP/ndens/K_B/eV;


### PR DESCRIPTION
Fixed the Ar-H2 chemistry issue where diffusion coefficients were incorrectly defaulting to Ar+.

Standardized chemistry mechanisms across the repository to use a non-zero dummy diffusion coefficient initializer (`dcoeff = 1e-12`) to avoid zero-diffusion values that can destabilize linear solves, with requested exceptions preserved as `dcoeff = 0.0` in `test/verification/Advect` and `test/zeroD_Reactors` cases.